### PR TITLE
MNT: Use noarch python {{ python_min }} variable

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,10 @@
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.9'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,12 +31,12 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
+mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
+echo > /opt/conda/conda-meta/history
+micromamba install --root-prefix ~/.conda --prefix /opt/conda \
+    --yes --override-channels --channel conda-forge --strict-channel-priority \
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
-
-mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -73,8 +73,8 @@ else
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
-    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir "${RECIPE_ROOT}" -m "${CONFIG_FILE}" || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 
     ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package license: BSD-3-Clause
 
 Summary: Units and constants in the HEP system of units
 
+Development: https://github.com/scikit-hep/hepunits
+
 Current build status
 ====================
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,5 +2,30 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
+stages:
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-22.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - checkout: self
+        fetchDepth: '2'
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+        displayName: Obtain commit message
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
+        displayName: Skip build?
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+        displayName: Export result
+- stage: Build
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "hepunits" %}
 {% set version = "2.3.5" %}
+{% set python_min = "3.8" %}
 
 
 package:
@@ -7,23 +8,23 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hepunits-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/hepunits-{{ version }}.tar.gz
   sha256: 9434cd2d6a722c949e9e9e22bd0b59587f69025bd37356e5c70635f1b37036d8
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python !=3.0,!=3.1,!=3.2,!=3.3,!=3.4
+    - python {{ python_min }}
     - hatchling
     - hatch-vcs
     - toml
   run:
-    - python !=3.0,!=3.1,!=3.2,!=3.3,!=3.4
+    - python >={{ python_min }}
 
 test:
   imports:
@@ -32,6 +33,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:
@@ -39,6 +41,7 @@ about:
   summary: Units and constants in the HEP system of units
   license: BSD-3-Clause
   license_file: LICENSE
+  dev_url: https://github.com/scikit-hep/hepunits
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
* Use 'python {{ python_min }}' syntax for the python requirements for noarch python recipes.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python
* Use a Jinja2 set statement for python_min to keep all the build metadata contained in the recipe/meta.yaml and override the global python_min with hepunits' python_min of 3.8.
* Add dev links to metadata.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
